### PR TITLE
Refactor Filtering logic and update to use tracing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "vita"
-version = "0.1.12"
+version = "0.1.13"
 authors = ["Junn <likesgophers@gmail.com>"]
+description = "vita is a tool to gather subdomains from passive sources"
+categories = ["command-line-utilities", "passive reconnaissance"]
+keywords = ["recon", "passive", "subdomain enumeration"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -14,17 +17,17 @@ name = "vita"
 reqwest = {version = "0.10.7", features = ["json"]}
 crobat = {path = "./crobat" }
 base64 = "0.12.3"
+addr = "0.2.0"
 clap = "2.33.1"
-regex = "1.3.9"
 url = "2.1.1"
 futures = "0.3.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 dotenv = "0.15.0"
 tokio = { version = "0.2", features = ["sync", "rt-threaded", "macros"] }
-lazy_static = "1.4.0"
-log = "0.4"
-pretty_env_logger = "0.4"
+tracing = {version = "0.1.19", features = ["attributes"]}
+tracing-futures = "0.2.4"
+tracing-subscriber = "0.2.12"
 
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
 openssl = { version = "0.10", features = ["vendored"] }

--- a/src/sources/anubisdb.rs
+++ b/src/sources/anubisdb.rs
@@ -4,6 +4,7 @@ use reqwest::Client;
 use serde_json::value::Value;
 use std::sync::Arc;
 use tokio::sync::mpsc::Sender;
+use tracing::{info, trace, warn};
 
 struct AnubisResult {
     results: Value,
@@ -21,7 +22,7 @@ impl IntoSubdomain for AnubisResult {
             .as_array()
             .unwrap()
             .iter()
-            .map(|s| s.as_str().unwrap().into())
+            .map(|s| s.to_string())
             .collect()
     }
 }
@@ -30,6 +31,8 @@ fn build_url(host: &str) -> String {
     format!("https://jldc.me/anubis/subdomains/{}", host)
 }
 
+//TODO: `Result` should be std::result::Result<(), Error::source_error>
+// the `run` should be a method on a struct `AnubisDB` or a trait across the whole project?
 pub async fn run(client: Client, host: Arc<String>, mut sender: Sender<Vec<String>>) -> Result<()> {
     trace!("fetching data from anubisdb for: {}", &host);
     let uri = build_url(&host);

--- a/src/sources/binaryedge.rs
+++ b/src/sources/binaryedge.rs
@@ -7,6 +7,7 @@ use serde::Deserialize;
 use std::env;
 use std::sync::Arc;
 use tokio::sync::mpsc::Sender;
+use tracing::{info, trace};
 
 struct Creds {
     token: String,
@@ -32,7 +33,7 @@ struct BinaryEdgeResponse {
 
 impl IntoSubdomain for BinaryEdgeResponse {
     fn subdomains(&self) -> Vec<String> {
-        self.events.iter().map(|s| s.into()).collect()
+        self.events.iter().map(|s| s.to_owned()).collect()
     }
 }
 

--- a/src/sources/c99.rs
+++ b/src/sources/c99.rs
@@ -6,6 +6,7 @@ use serde::Deserialize;
 use std::env;
 use std::sync::Arc;
 use tokio::sync::mpsc::Sender;
+use tracing::{info, trace, warn};
 
 struct Creds {
     key: String,

--- a/src/sources/certspotter.rs
+++ b/src/sources/certspotter.rs
@@ -4,6 +4,7 @@ use reqwest::Client;
 use serde::Deserialize;
 use std::sync::Arc;
 use tokio::sync::mpsc::Sender;
+use tracing::{debug, info, trace, warn};
 
 #[derive(Debug, Deserialize)]
 struct CertSpotterResult {

--- a/src/sources/chaos.rs
+++ b/src/sources/chaos.rs
@@ -7,6 +7,7 @@ use serde::Deserialize;
 use std::env;
 use std::sync::Arc;
 use tokio::sync::mpsc::Sender;
+use tracing::{info, trace, warn};
 
 struct Creds {
     key: String,

--- a/src/sources/crtsh.rs
+++ b/src/sources/crtsh.rs
@@ -4,6 +4,7 @@ use reqwest::Client;
 use serde::Deserialize;
 use std::sync::Arc;
 use tokio::sync::mpsc::Sender;
+use tracing::{debug, info, trace, warn};
 
 #[derive(Deserialize, Hash, PartialEq, Debug, Eq)]
 struct CrtshResult {

--- a/src/sources/facebook.rs
+++ b/src/sources/facebook.rs
@@ -6,6 +6,7 @@ use serde::Deserialize;
 use std::env;
 use std::sync::Arc;
 use tokio::sync::mpsc::Sender;
+use tracing::{info, warn};
 
 #[derive(Debug, PartialEq)]
 struct Creds {

--- a/src/sources/hackertarget.rs
+++ b/src/sources/hackertarget.rs
@@ -3,6 +3,7 @@ use crate::IntoSubdomain;
 use reqwest::Client;
 use std::sync::Arc;
 use tokio::sync::mpsc::Sender;
+use tracing::{debug, info, trace, warn};
 
 const API_ERROR: &str = "error check your search parameter";
 

--- a/src/sources/intelx.rs
+++ b/src/sources/intelx.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use std::env;
 use std::sync::Arc;
 use tokio::sync::mpsc::Sender;
+use tracing::{debug, info, trace, warn};
 
 struct Creds {
     url: String,

--- a/src/sources/passivetotal.rs
+++ b/src/sources/passivetotal.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 use std::env;
 use std::sync::Arc;
 use tokio::sync::mpsc::Sender;
+use tracing::{info, trace, warn};
 
 struct Creds {
     key: String,

--- a/src/sources/securitytrails.rs
+++ b/src/sources/securitytrails.rs
@@ -6,6 +6,7 @@ use serde::Deserialize;
 use std::env;
 use std::sync::Arc;
 use tokio::sync::mpsc::Sender;
+use tracing::{info, trace, warn};
 
 struct Creds {
     api_key: String,

--- a/src/sources/sonarsearch.rs
+++ b/src/sources/sonarsearch.rs
@@ -3,6 +3,7 @@ use crate::error::Result;
 use crobat::Crobat;
 use std::sync::Arc;
 use tokio::sync::mpsc::Sender;
+use tracing::{info, warn};
 
 pub async fn run(host: Arc<String>, mut sender: Sender<Vec<String>>) -> Result<()> {
     let mut client = Crobat::new().await;

--- a/src/sources/spyse.rs
+++ b/src/sources/spyse.rs
@@ -7,6 +7,7 @@ use serde::Deserialize;
 use std::env;
 use std::sync::Arc;
 use tokio::sync::mpsc::Sender;
+use tracing::{info, trace, warn};
 
 struct Creds {
     token: String,

--- a/src/sources/sublister.rs
+++ b/src/sources/sublister.rs
@@ -4,6 +4,7 @@ use reqwest::Client;
 use serde_json::value::Value;
 use std::sync::Arc;
 use tokio::sync::mpsc::Sender;
+use tracing::{debug, info, trace, warn};
 
 struct SublisterResult {
     items: Vec<Value>,

--- a/src/sources/threatcrowd.rs
+++ b/src/sources/threatcrowd.rs
@@ -4,6 +4,7 @@ use reqwest::Client;
 use serde::Deserialize;
 use std::sync::Arc;
 use tokio::sync::mpsc::Sender;
+use tracing::{debug, info, trace, warn};
 
 #[derive(Debug, Deserialize)]
 struct ThreatCrowdResult {

--- a/src/sources/threatminer.rs
+++ b/src/sources/threatminer.rs
@@ -4,6 +4,7 @@ use reqwest::Client;
 use serde::Deserialize;
 use std::sync::Arc;
 use tokio::sync::mpsc::Sender;
+use tracing::{info, trace, warn};
 
 #[derive(Deserialize)]
 struct ThreatminerResult {

--- a/src/sources/urlscan.rs
+++ b/src/sources/urlscan.rs
@@ -4,6 +4,7 @@ use reqwest::Client;
 use serde::Deserialize;
 use std::sync::Arc;
 use tokio::sync::mpsc::Sender;
+use tracing::{error, info, trace, warn};
 
 #[derive(Deserialize, Hash, Eq, PartialEq)]
 struct UrlScanPage {

--- a/src/sources/virustotal.rs
+++ b/src/sources/virustotal.rs
@@ -4,6 +4,7 @@ use reqwest::Client;
 use serde::Deserialize;
 use std::sync::Arc;
 use tokio::sync::mpsc::Sender;
+use tracing::{error, info, trace, warn};
 
 #[derive(Deserialize)]
 struct Subdomain {

--- a/src/sources/wayback.rs
+++ b/src/sources/wayback.rs
@@ -4,6 +4,7 @@ use reqwest::Client;
 use serde_json::value::Value;
 use std::sync::Arc;
 use tokio::sync::mpsc::Sender;
+use tracing::{error, info, trace, warn};
 use url::Url;
 
 struct WaybackResult {


### PR DESCRIPTION
This commit has refactored the filtering logic to use the [addr](https://github.com/addr-rs/addr) crate. The previous solution to filtering the irrelevant results used a regex set which would match the root domain against the domains you provided as input.  Some advantages of the new solution to the previous:

- More robust 
- Less overhead (when providing a large list of domains as input, the regex set would take some time to construct)
- Cleaner solution

Other changes:
- The filtering logic has been moved out of the `src/bin/main.rs` and into it's own struct in the `src/lib.rs`
- User input is now filtered for duplicate entries.
- `Runner.run` method will now process results concurrently. 