### PR TITLE
Fix `None` handling errors

### DIFF
--- a/src/sources/anubisdb.rs
+++ b/src/sources/anubisdb.rs
@@ -18,12 +18,10 @@ impl AnubisResult {
 
 impl IntoSubdomain for AnubisResult {
     fn subdomains(&self) -> Vec<String> {
-        self.results
-            .as_array()
-            .unwrap()
-            .iter()
-            .map(|s| s.to_string())
-            .collect()
+        match self.results.as_array() {
+            Some(array) => array.iter().map(|s| s.to_string()).collect(),
+            None => Vec::new(),
+        }
     }
 }
 

--- a/src/sources/wayback.rs
+++ b/src/sources/wayback.rs
@@ -23,8 +23,11 @@ impl IntoSubdomain for WaybackResult {
         let arr = self.data.as_array().unwrap();
         let vecs: Vec<&str> = arr.iter().map(|s| s[0].as_str().unwrap()).collect();
         vecs.into_iter()
-            .filter_map(|a| Url::parse(a).ok())
-            .map(|u| u.host_str().unwrap().into())
+            .filter_map(|a| {
+                Url::parse(a)
+                    .ok()
+                    .and_then(|u| u.host_str().map(|h| h.into()))
+            })
             .collect()
     }
 }


### PR DESCRIPTION
These are recurring errors in my logs:

```
thread 'tokio-runtime-worker' panicked at 'called `Option::unwrap()` on a `None` value', src/sources/anubisdb.rs:23:14
thread 'tokio-runtime-worker' panicked at 'called `Option::unwrap()` on a `None` value', src/sources/wayback.rs:27:35
```

This PR fixes those.