### PR TITLE
Handle SonarSearch panic

### DIFF
--- a/crobat/src/lib.rs
+++ b/crobat/src/lib.rs
@@ -22,13 +22,14 @@ pub struct Crobat {
 }
 
 impl Crobat {
-    pub async fn new() -> Self {
+    pub async fn connect() -> Result<Self> {
         trace!("building crobat client");
         let addr = "https://crobat-rpc.omnisint.io";
-        let conn = Crobat::build_tls_client(addr).await.unwrap();
-
-        Self {
-            client: CrobatClient::new(conn),
+        match Crobat::build_tls_client(addr).await {
+            Ok(conn) => Ok(Self {
+                client: CrobatClient::new(conn),
+            }),
+            Err(e) => Err(e),
         }
     }
 

--- a/src/sources/sonarsearch.rs
+++ b/src/sources/sonarsearch.rs
@@ -23,7 +23,7 @@ impl SonarSearch {
 impl DataSource for SonarSearch {
     async fn run(&self, host: Arc<String>, mut tx: Sender<Vec<String>>) -> Result<()> {
         let mut results = Vec::with_capacity(QUEUE_SIZE);
-        let mut client = Crobat::new().await;
+        let mut client = Crobat::connect().await?;
         let mut subs = client.get_subs(host.clone()).await?;
 
         while let Some(r) = subs.next().await {


### PR DESCRIPTION
Following my investigation in https://github.com/junnlikestea/vita/issues/28#issuecomment-739110678, I decided to add a `127.0.0.1       crobat-rpc.omnisint.io` line to my `/etc/hosts` file. Unfortunately, that caused panics in Vita.

This PR handles the case when the network connection can't be established with the SonarSearch API domain.