### PR TITLE
Enable gzip compression in the reqwest client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/bin/main.rs"
 name = "vita"
 
 [dependencies]
-reqwest = {version = "0.10.7", features = ["json"]}
+reqwest = {version = "0.10.7", features = ["json", "gzip"]}
 strum = "0.20"
 strum_macros = "0.20"
 matches = "0.1.8"

--- a/src/sources/facebook.rs
+++ b/src/sources/facebook.rs
@@ -125,7 +125,6 @@ mod tests {
     use super::*;
     use crate::client;
     use matches::matches;
-    use std::time::Duration;
     use tokio::sync::mpsc::channel;
 
     // checks if we can fetch the credentials from an .env file.


### PR DESCRIPTION
I'm reading `reqwest` docs for a personal project and noticed this part: https://docs.rs/reqwest/0.11.0/reqwest/struct.ClientBuilder.html#method.gzip

Enabling the `gzip` feature adds a `accept-encoding: gzip` header to all requests and automatically handles the decompression. Given the type of data that Vita handles this should help with performance and bandwidth.

Just to make sure I ran

```rust
use reqwest::Client;

#[tokio::main]
async fn main() {
    let client = Client::builder().build().unwrap();
    client.get("http://localhost:1234").send().await;
}
```
with

```toml
reqwest = { version = "0.11", features = ["gzip"] }
```

and

```toml
reqwest = { version = "0.11", features = [] }
```

and could confirm with my `nc` listener that the header was indeed missing by default without the feature.